### PR TITLE
Update setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -33,7 +33,14 @@ keywords =
     create-aio-app
     cookiecutter==1.7.3
     aiohttp
+[flake8]
+max-line-length = 88
+[metadata]
+name = create-aio-app
+version = attr: create_aio_app.__version__
 
+[flake8]
+max-line-length = 88
 
 [options]
 packages = find_namespace:
@@ -51,3 +58,4 @@ install_requires =
 [options.entry_points]
 console_scripts =
     create-aio-app = create_aio_app.main:main
+


### PR DESCRIPTION
This PR resolves the conflict between black and flake8 line length rules by adding a [flake8] section to setup.cfg, setting max-line-length = 88.

This aligns both tools with the same formatting standard and prevents future linting issues.

Fixes #176.